### PR TITLE
feat: Add custom top app bar and update navigation

### DIFF
--- a/app/src/main/java/com/mundocode/pomodoro/core/navigation/Destinations.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/core/navigation/Destinations.kt
@@ -14,13 +14,10 @@ sealed interface Destinations : Destination {
 
     @Serializable
     data class TimerScreen(val timer: Timer) : Destinations
-  
-    @Serializable
-    data object Timer : Destinations
 
     @Serializable
     data object Task : Destinations
-  
+
     @Serializable
     data object Habits : Destinations
 }

--- a/app/src/main/java/com/mundocode/pomodoro/core/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/core/navigation/NavigationRoot.kt
@@ -27,6 +27,7 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
     ) {
         composable<Destinations.HomeScreen> {
             HomeScreen(
+                navController = navController,
                 navigateTo = { destination ->
                     navController.kiwiNavigate(destination)
                 },
@@ -34,6 +35,7 @@ fun NavigationRoot(modifier: Modifier = Modifier) {
         }
         composable<Destinations.SetupSessionScreen> {
             SetupSessionScreen(
+                navController = navController,
                 navigateTo = { destination ->
                     navController.kiwiNavigate(destination)
                 },

--- a/app/src/main/java/com/mundocode/pomodoro/ui/components/customTopAppBar.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/components/customTopAppBar.kt
@@ -1,0 +1,93 @@
+package com.mundocode.pomodoro.ui.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.navigation.NavController
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomTopAppBar(
+    navController: NavController,
+    title: String,
+    navigationIcon: @Composable () -> Unit = {},
+) {
+    var isMenuExpanded by remember { mutableStateOf(false) }
+
+    TopAppBar(
+        title = { Text(text = title) },
+        navigationIcon = navigationIcon,
+        actions = {
+            IconButton(onClick = { isMenuExpanded = true }) {
+                Icon(
+                    imageVector = Icons.Outlined.AccountCircle,
+                    contentDescription = "Open Menu",
+                    modifier = Modifier.size(60.dp)
+                )
+            }
+            DropdownMenu(
+                expanded = isMenuExpanded,
+                onDismissRequest = { isMenuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    onClick = {
+                        isMenuExpanded = false
+                        navController.navigate("screen1")
+                    },
+                    text = {
+                        Text("Screen 1")
+                    },
+                )
+                DropdownMenuItem(
+                    onClick = {
+                        isMenuExpanded = false
+                        navController.navigate("screen2")
+                    },
+                    text = {
+                        Text("Screen 2")
+                    },
+                )
+                DropdownMenuItem(
+                    onClick = {
+                        isMenuExpanded = false
+                        navController.navigate("screen3")
+                    },
+                    text = {
+                        Text("Configuración")
+                    },
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            titleContentColor = MaterialTheme.colorScheme.primary,
+        )
+    )
+}
+
+@Preview
+@Composable
+fun PreviewCustomTopAppBar() {
+    CustomTopAppBar(
+        navController = NavController(LocalContext.current),
+        title = "Custom Top App Bar",
+    )
+}

--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/TaskScreen/TaskScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/TaskScreen/TaskScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.mundocode.pomodoro.R
+import com.mundocode.pomodoro.ui.components.CustomTopAppBar
 
 @Composable
 fun TaskItem(
@@ -71,23 +72,18 @@ fun TaskScreen(navController: NavController) {
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(text = stringResource(id = R.string.app_name))
-                },
+            CustomTopAppBar(
+                navController = navController,
+                title = stringResource(id = R.string.app_name),
                 navigationIcon = {
                     IconButton(onClick = { navController.navigateUp() }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             tint = MaterialTheme.colorScheme.onSurface,
-                            contentDescription = "Localized description"
+                            contentDescription = "Localized description",
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.primary,
-                ),
             )
         },
     ) { padding ->

--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/habits/HabitsScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/habits/HabitsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -18,7 +17,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -28,7 +26,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -38,16 +35,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.mundocode.pomodoro.R
+import com.mundocode.pomodoro.ui.components.CustomTopAppBar
 import com.mundocode.pomodoro.viewModels.habitsViewModel.HabitsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,10 +56,9 @@ fun HabitsScreen(viewModel: HabitsViewModel = hiltViewModel(), navController: Na
     MaterialTheme {
         Scaffold(
             topBar = {
-                CenterAlignedTopAppBar(
-                    title = {
-                        Text(text = stringResource(id = R.string.app_name))
-                    },
+                CustomTopAppBar(
+                    navController = navController,
+                    title = stringResource(R.string.app_name),
                     navigationIcon = {
                         IconButton(onClick = { navController.navigateUp() }) {
                             Icon(
@@ -69,10 +68,6 @@ fun HabitsScreen(viewModel: HabitsViewModel = hiltViewModel(), navController: Na
                             )
                         }
                     },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        titleContentColor = MaterialTheme.colorScheme.primary,
-                    ),
                 )
             },
             floatingActionButton = {
@@ -119,7 +114,16 @@ fun HabitsScreen(viewModel: HabitsViewModel = hiltViewModel(), navController: Na
                 Spacer(modifier = Modifier.height(16.dp))
 
                 // RecyclerView (LazyColumn)
-                val items = listOf("Elemento 1", "Elemento 2", "Elemento 3", "Elemento 4", "Elemento 5", "Elemento 6", "Elemento 7")
+                val items =
+                    listOf(
+                        "Elemento 1",
+                        "Elemento 2",
+                        "Elemento 3",
+                        "Elemento 4",
+                        "Elemento 5",
+                        "Elemento 6",
+                        "Elemento 7",
+                    )
                 LazyColumn {
                     items(items) { item ->
                         MyCard(item)
@@ -201,7 +205,7 @@ fun TextInputPopup(viewModel: HabitsViewModel, onDismiss: () -> Unit) {
                     Column(
                         modifier = Modifier.weight(1f).padding(8.dp),
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         Button(
                             onClick = {
@@ -212,19 +216,24 @@ fun TextInputPopup(viewModel: HabitsViewModel, onDismiss: () -> Unit) {
                         ) {
                             Text("Guardar")
                         }
-
                     }
                     Column(
                         modifier = Modifier.weight(1f).padding(8.dp),
                         verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                    Button(onClick = { onDismiss() }) {
-                        Text("Cancelar")
+                        Button(onClick = { onDismiss() }) {
+                            Text("Cancelar")
+                        }
                     }
-                }}
+                }
             }
         }
     }
 }
 
+@Preview()
+@Composable
+fun HabitsScreenPreview() {
+    HabitsScreen(navController = NavController(LocalContext.current))
+}

--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/homeScreen/HomeScreen.kt
@@ -13,10 +13,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,15 +33,34 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import com.mundocode.pomodoro.R
 import com.mundocode.pomodoro.core.navigation.Destinations
+import com.mundocode.pomodoro.ui.components.CustomTopAppBar
 
-@Preview
 @Composable
-fun HomeScreen(navigateTo: (Destinations) -> Unit = {}) {
+fun HomeScreen(
+    navigateTo: (Destinations) -> Unit = {},
+    navController: NavController,
+) {
     val context = LocalContext.current
 
     Scaffold(
+        topBar = {
+            CustomTopAppBar(
+                navController = navController,
+                title = "Pomodoro",
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            contentDescription = "Localized description",
+                        )
+                    }
+                },
+            )
+        },
         modifier = Modifier.fillMaxSize(),
     ) { padding ->
         Column(
@@ -201,4 +223,13 @@ fun OptionButtons(color: Long, textButton: String, icon: Int, descriptionIcon: S
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+    HomeScreen(
+        navigateTo = {},
+        navController = NavController(LocalContext.current),
+    )
 }

--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/setupSessionScreen/SetupSessionScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/setupSessionScreen/SetupSessionScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -33,23 +35,34 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import com.mundocode.pomodoro.R
 import com.mundocode.pomodoro.core.navigation.Destinations
+import com.mundocode.pomodoro.ui.components.CustomTopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SetupSessionScreen(viewModel: SetupSessionViewModel = hiltViewModel(), navigateTo: (Destinations) -> Unit = {}) {
+fun SetupSessionScreen(
+    viewModel: SetupSessionViewModel = hiltViewModel(),
+    navigateTo: (Destinations) -> Unit = {},
+    navController: NavController,
+) {
     val state by viewModel.sessionState.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Configurar Sesión Pomodoro") }, // TODO: Extract string
-                colors =
-                TopAppBarDefaults.topAppBarColors(
-                    containerColor = Color(0xFFD9D9D9), // TODO: Use theme color instead of this harcoded one
-                    titleContentColor = Color.Black,
-                ),
+            CustomTopAppBar(
+                navController = navController,
+                title = "Configurar sesión Pomodoro",
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            contentDescription = "Localized description",
+                        )
+                    }
+                },
             )
         },
     ) { padding ->

--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/timer/TimerScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/timer/TimerScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -22,13 +21,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -40,6 +39,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.mundocode.pomodoro.R
 import com.mundocode.pomodoro.model.local.Timer
+import com.mundocode.pomodoro.ui.components.CustomTopAppBar
 import com.mundocode.pomodoro.ui.theme.PomodoroTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,10 +61,9 @@ fun TimerScreen(timer: Timer, navController: NavController, viewModel: TimerView
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(text = timer.sessionName)
-                },
+            CustomTopAppBar(
+                navController = navController,
+                title = timer.sessionName,
                 navigationIcon = {
                     IconButton(onClick = { navController.navigateUp() }) {
                         Icon(
@@ -74,10 +73,6 @@ fun TimerScreen(timer: Timer, navController: NavController, viewModel: TimerView
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.primary,
-                ),
             )
         },
     ) { paddingValues ->
@@ -224,10 +219,18 @@ fun TimerContent(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
-fun TimerContentPreview() {
+fun TimerScreenPreview() {
     PomodoroTheme {
-        TimerContent(timerState = TimerState())
+        TimerScreen(
+            timer = Timer(
+                sessionName = "Sesión 1",
+                mode = "Trabajo",
+                timer = "1:00",
+                pause = "1:00",
+            ),
+            navController = NavController(LocalContext.current),
+        )
     }
 }


### PR DESCRIPTION
- Added a custom `CustomTopAppBar` component for consistent app bar design.
- Replaced `CenterAlignedTopAppBar` with `CustomTopAppBar` in `HabitsScreen`, `TaskScreen`, `TimerScreen`, and `HomeScreen`.
- Added a back navigation arrow and a profile menu to the `CustomTopAppBar`.
- Updated the `SetupSessionScreen` to use `CustomTopAppBar` with a back button.
- Implemented navigation using `navController` in the `CustomTopAppBar`.
- Added `HomeScreenPreview` and `TimerScreenPreview` to improve visualization.
- Removed unused `Timer` route from `Destinations`.