### PR TITLE
feat: Improve login navigation and calendar day highlighting

### DIFF
--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/homeScreen/HomeScreen.kt
@@ -522,7 +522,8 @@ fun ProductivityCalendar(sessionsData: Map<String, Float>) {
                         .background(
                             when {
                                 day == null -> Color.Transparent
-                                day == today.get(Calendar.DAY_OF_MONTH) -> Color(0xFF03A9F4) // 🔹 Azul para el día que es actual
+                                // 🔹 Azul para el día que es actual
+                                day == today.get(Calendar.DAY_OF_MONTH) -> Color(0xFF03A9F4)
                                 sessionTime >= 60 -> Color.Green // 🟢 Alta productividad
                                 sessionTime in 30f..59f -> Color.Yellow // 🟡 Media productividad
                                 sessionTime in 1f..29f -> Color.Red // 🔴 Baja productividad

--- a/app/src/main/java/com/mundocode/pomodoro/ui/screens/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/mundocode/pomodoro/ui/screens/loginScreen/LoginScreen.kt
@@ -62,9 +62,9 @@ fun LoginScreen(navController: NavController, viewModel: LoginViewModel = hiltVi
 
     LaunchedEffect(loginSuccess) {
         if (loginSuccess) {
-            navController.kiwiNavigation(Destinations.HomeScreen) { popUpTo("login") { inclusive = true } }
-        } else {
-            navController.kiwiNavigation(Destinations.Login) { popUpTo("home") { inclusive = true } }
+            navController.kiwiNavigation(Destinations.HomeScreen) {
+                popUpTo(Destinations.Login) { inclusive = true }
+            }
         }
     }
 


### PR DESCRIPTION
- Modified the navigation logic in `LoginScreen` to correctly pop up to the login route when login is successful.
- Enhanced `CalendarView` in `HomeScreen` to use a clearer comment for highlighting the current day with blue color.
- Refactor `LoginScreen` to use Destinations instead string for popUpTo.